### PR TITLE
 Add unsafe delete button and keybind

### DIFF
--- a/image_labelling_tool/static/labelling_tool/main_labeller.js
+++ b/image_labelling_tool/static/labelling_tool/main_labeller.js
@@ -245,6 +245,8 @@ var labelling_tool;
             this._lockableControls = $('.anno_lockable');
             // Toggle ability to right click (Keybind: L)
             this._lockRightClick = false;
+            // Allow for permanent unsafe delete (delete without modal popup)
+            this._allowPermanentDelete = false;
             /*
              *
              *
@@ -522,6 +524,11 @@ var labelling_tool;
                     confirm_button.button().click(function (event) {
                         self.root_view.delete_selection(canDelete);
                     });
+                });
+
+                var unsafe_delete_label_button = $('#unsafe_delete_label_button');
+                unsafe_delete_label_button.click(function (event) {
+                    self.root_view.delete_selection(canDelete);
                 });
             }
             if (config.tools.labelClassSelector) {
@@ -850,6 +857,13 @@ var labelling_tool;
                 this._lockRightClick = !this._lockRightClick;
                 toggleLockIcon();
 
+                handled = true;
+            }
+
+            // DEL to Unsafe Delete
+            if (event.keyCode === 46) {
+                var unsafe_delete_label_button = $('#unsafe_delete_label_button');
+                if (unsafe_delete_label_button) unsafe_delete_label_button.click();
                 handled = true;
             }
 

--- a/image_labelling_tool/templates/inline/labeller_app.html
+++ b/image_labelling_tool/templates/inline/labeller_app.html
@@ -178,22 +178,29 @@
 
             <div class="collapse show tool_bar_group" id="tool_group_select">
 
-                <div class="tool_bar_content">
-                    {% if not labelling_tool_config.tools.deleteLabel == False %}
-                        <button class="btn btn-sm btn-danger w-25 float-right" type="button" id="delete_label_button" data-toggle="tooltip"
+                <div class=" row w-100 tool_bar_content">
+                    <div class="col d-flex flex-column justify-content-start align-items-start">
+                        <button class="btn btn-sm btn-info w-50 mb-1" type="button" id="select_pick_button" data-toggle="tooltip"
+                                data-placement="top" title="Pick labels one at a time, hold &lt;shift&gt; for multiple
+                                selection">Pick</button>
+                        {% if not labelling_tool_config.tools.brushSelect == False %}
+                        <button class="btn btn-sm btn-info w-50 mb-1" type="button" id="select_brush_button" data-toggle="tooltip"
+                                data-placement="top" title="Select labels by sweeping a brush over them,
+                                change brush size with &lt;shift&gt;+scroll">Brush</button>
+                        {% endif %}
+                    </div>
+                    <div class="col d-flex flex-column justify-content-end align-items-end">
+                        {% if not labelling_tool_config.tools.deleteLabel == False %}
+                        <button class="btn btn-sm btn-warning w-50 mb-1" type="button" id="delete_label_button" data-toggle="tooltip"
                                 data-placement="top" title="Delete selected labels (groups will be opened; the group will
-                                be deleted but its members will remain)">
+                                    be deleted but its members will remain)">
                             <span class="oi oi-trash"></span></button>
-                    {% endif %}
-
-                    <button class="btn btn-sm btn-info w-25 mb-1" type="button" id="select_pick_button" data-toggle="tooltip"
-                            data-placement="top" title="Pick labels one at a time, hold &lt;shift&gt; for multiple
-                            selection">Pick</button>
-                    {% if not labelling_tool_config.tools.brushSelect == False %}
-                        <button class="btn btn-sm btn-info w-25 mb-1" type="button" id="select_brush_button" data-toggle="tooltip"
-                            data-placement="top" title="Select labels by sweeping a brush over them,
-                            change brush size with &lt;shift&gt;+scroll">Brush</button>
-                    {% endif %}
+                        <button class="btn btn-sm btn-danger w-50 mb-1" type="button" id="unsafe_delete_label_button" data-toggle="tooltip"
+                                data-placement="top" title="Delete selected labels WITHOUT first providing a prompt (groups will be opened; the group will
+                                    be deleted but its members will remain)">
+                            <span class="oi oi-trash"></span></button>
+                        {% endif %}
+                    </div>
                 </div>
 
                 {% if not labelling_tool_config.tools.labelClassSelector == False %}


### PR DESCRIPTION
# Author Checklist
- [x] I have reviewed my work
- [x] My commits are concise and descriptive
- [x] My changes work as expected
- [x] Associated functionality has not broken
- [x] I am proud (or at least satisfied) with this work
- [x] I believe these changes are ready for production

# Overview

This PR adds a feature that allows a label to be deleted without a safety check popup through the use of the delete key or the new unsafe delete button. It also modifies the html structure and style of the buttons surrounding the unsafe delete to accommodate it and make it clear which delete does which.

## Screenshots

![image](https://github.com/elevatesystems/django-labeller/assets/118487667/60e1facf-d96b-4962-9f19-140197e6892f)
