### PR TITLE
Ease of use for table labeling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,152 @@
+# OSX
+**.DS_Store
+
+# JetBrains
+.idea/
+.idea/*
+
+# Personal Files
+my/*
+
+# VSCode
+.vscode/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Jupyter Notebook config
+.jupyter/
+
+# Jupyter Notebook files
+nbs/images/
+nbs/output/
+nbs/datasets/
+nbs/debug/
+nbs/*.jpg
+nbs/*.pth
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/image_labelling_tool/flask_labeller.py
+++ b/image_labelling_tool/flask_labeller.py
@@ -42,7 +42,8 @@ except ImportError:
     SocketIO = None
     socketio_emit = None
 
-
+# Allow the loading of large images
+Image.MAX_IMAGE_PIXELS = None
 DextrImageType = Union[np.ndarray, Image.Image]
 DextrFunctionType = Callable[[DextrImageType, np.ndarray], np.ndarray]
 

--- a/image_labelling_tool/static/labelling_tool/box_label.js
+++ b/image_labelling_tool/static/labelling_tool/box_label.js
@@ -58,7 +58,9 @@ var labelling_tool;
     var BoxLabelEntity = /** @class */ (function (_super) {
         __extends(BoxLabelEntity, _super);
         function BoxLabelEntity(view, model) {
-            return _super.call(this, view, model) || this;
+            var _this = _super.call(this, view, model) || this;
+            _this._table = null;
+            return _this;
         }
         BoxLabelEntity.prototype.attach = function () {
             _super.prototype.attach.call(this);
@@ -138,6 +140,54 @@ var labelling_tool;
         };
         BoxLabelEntity.prototype.distance_to_point = function (point) {
             return BoxLabel_box(this.model).distance_to(point);
+        };
+        BoxLabelEntity.prototype.is_table_structure_label = function (label) {
+            var _a;
+            var label_class = label !== null && label !== void 0 ? label : (_a = this === null || this === void 0 ? void 0 : this.model) === null || _a === void 0 ? void 0 : _a.label_class;
+            if (label_class === null || label_class === undefined)
+                return false;
+            var table_structure_classes = [
+                "table_column",
+                "table_column_header",
+                "table_projected_row_header",
+                "table_row",
+                "table_spanning_cell",
+            ];
+            return table_structure_classes.indexOf(label_class) !== -1;
+        };
+        BoxLabelEntity.prototype.get_parent_table = function () {
+            var _this = this;
+            if (this._table !== null)
+                return this._table;
+            if (!this.is_table_structure_label())
+                return null;
+            var entity_id = this.get_entity_id();
+            var entities = this.root_view.get_entities();
+            var table_entities = entities.filter(function (e) { return e.model.label_class === "table"; });
+            table_entities.forEach(function (entity) {
+                if (entity.distance_to_point(_this.compute_centroid()) < 10) {
+                    var bbox_1 = entity.compute_bounding_box();
+                    var columns = entities.filter(function (e) {
+                        return entity_id !== e.get_entity_id() && e.model.label_class === "table_column" && bbox_1.contains_point(e.compute_bounding_box().centre());
+                    }).map(function (e) { return e.compute_bounding_box(); });
+                    var rows = entities.filter(function (e) {
+                        return entity_id !== e.get_entity_id() && e.model.label_class === "table_row" && bbox_1.contains_point(e.compute_bounding_box().centre());
+                    }).map(function (e) { return e.compute_bounding_box(); });
+                    _this._table = {
+                        bbox: bbox_1,
+                        columns: columns,
+                        entity: entity,
+                        label: _this.model.label_class,
+                        rows: rows,
+                        threshold: {
+                            x: Math.max(10, Math.ceil((bbox_1.upper.x - bbox_1.lower.x) / 100)),
+                            y: Math.max(10, Math.ceil((bbox_1.upper.y - bbox_1.lower.y) / 100)),
+                        }
+                    };
+                    return _this._table;
+                }
+            });
+            return null;
         };
         return BoxLabelEntity;
     }(labelling_tool.AbstractLabelEntity));
@@ -234,11 +284,13 @@ var labelling_tool;
         };
         ;
         DrawBoxTool.prototype.update_box = function () {
+            var _a;
             if (this.entity !== null) {
                 var box = null;
                 if (this._start_point !== null) {
                     if (this._current_point !== null) {
                         box = labelling_tool.AABox_from_points([this._start_point, this._current_point]);
+                        box = (_a = this.get_table_box(this._start_point, this._current_point)) !== null && _a !== void 0 ? _a : box;
                     }
                     else {
                         box = new labelling_tool.AABox(this._start_point, this._start_point);
@@ -250,6 +302,69 @@ var labelling_tool;
             }
         };
         ;
+        DrawBoxTool.prototype.get_table_box = function (_start, _current) {
+            var table = this.entity.get_parent_table();
+            if (table === null)
+                return null;
+            var bbox = table.bbox;
+            var start = bbox.closest_point_to(_start);
+            var current = bbox.closest_point_to(_current);
+            var box = null;
+            if (table.label === "table_row" || table.label === "table_column_header" || table.label === "table_projected_row_header") {
+                // full width
+                start.x = bbox.closest_boundary_to(start).x;
+                current.x = start.x === bbox.lower.x ? bbox.upper.x : bbox.lower.x;
+                this._snap_to_table_boundary(start, current, table, "y");
+                this._snap_to_row_boundary(start, current, table);
+            }
+            else if (table.label === "table_column") {
+                // full height
+                start.y = bbox.closest_boundary_to(start).y;
+                current.y = start.y === bbox.lower.y ? bbox.upper.y : bbox.lower.y;
+                this._snap_to_table_boundary(start, current, table, "x");
+                this._snap_to_column_boundary(start, current, table);
+                // spanning cell
+            }
+            else {
+                this._snap_to_table_boundary(start, current, table);
+                this._snap_to_column_boundary(start, current, table);
+                this._snap_to_row_boundary(start, current, table);
+            }
+            this._start_point = start;
+            box = labelling_tool.AABox_from_points([start, current]);
+            return box;
+        };
+        DrawBoxTool.prototype._snap_to_table_boundary = function (start, current, table, type) {
+            if (type === undefined || type === "x") {
+                if (table.bbox.distance_to(start) < table.threshold.x)
+                    start.x = table.bbox.closest_point_to(start).x;
+                if (table.bbox.distance_to(current) < table.threshold.x)
+                    current.x = table.bbox.closest_point_to(current).x;
+            }
+            if (type === undefined || type === "y") {
+                if (table.bbox.distance_to(start) < table.threshold.y)
+                    start.y = table.bbox.closest_point_to(start).y;
+                if (table.bbox.distance_to(current) < table.threshold.y)
+                    current.y = table.bbox.closest_point_to(current).y;
+            }
+        };
+        // can break with below if matching multiple columns or rows
+        DrawBoxTool.prototype._snap_to_column_boundary = function (start, current, table) {
+            table.columns.forEach(function (col) {
+                if (col.distance_to(start) < table.threshold.x)
+                    start.x = col.closest_boundary_to(start).x;
+                if (col.distance_to(current) < table.threshold.x)
+                    current.x = col.closest_boundary_to(current).x;
+            });
+        };
+        DrawBoxTool.prototype._snap_to_row_boundary = function (start, current, table) {
+            table.rows.forEach(function (row) {
+                if (row.distance_to(start) < table.threshold.y)
+                    start.y = row.closest_boundary_to(start).y;
+                if (row.distance_to(current) < table.threshold.y)
+                    current.y = row.closest_boundary_to(current).y;
+            });
+        };
         return DrawBoxTool;
     }(labelling_tool.AbstractTool));
     labelling_tool.DrawBoxTool = DrawBoxTool;

--- a/image_labelling_tool/static/labelling_tool/box_label.ts
+++ b/image_labelling_tool/static/labelling_tool/box_label.ts
@@ -50,16 +50,26 @@ module labelling_tool {
         return new AABox(lower, upper);
     }
 
+    interface TableStructure {
+        bbox: AABox;
+        columns: AABox[];
+        entity: AbstractLabelEntity<AbstractLabelModel>;
+        label: string;
+        rows: AABox[];
+        threshold: Vector2;
+    }
 
     /*
     Box label entity
      */
     export class BoxLabelEntity extends AbstractLabelEntity<BoxLabelModel> {
         _rect: any;
+        _table: TableStructure|null;
 
 
         constructor(view: RootLabelView, model: BoxLabelModel) {
             super(view, model);
+            this._table = null;
         }
 
 
@@ -160,6 +170,54 @@ module labelling_tool {
 
         distance_to_point(point: Vector2): number {
             return BoxLabel_box(this.model).distance_to(point);
+        }
+
+        is_table_structure_label(label?: string): boolean {
+            const label_class = label ?? this?.model?.label_class;
+            if (label_class === null || label_class === undefined) return false;
+            const table_structure_classes = [
+                "table_column",
+                "table_column_header",
+                "table_projected_row_header",
+                "table_row",
+                "table_spanning_cell",
+            ]
+            return table_structure_classes.indexOf(label_class) !== -1;
+        }
+
+        get_parent_table(): TableStructure|null {
+            if (this._table !== null) return this._table;
+            if (!this.is_table_structure_label()) return null;
+            const entity_id = this.get_entity_id();
+
+            const entities: AbstractLabelEntity<AbstractLabelModel>[] = this.root_view.get_entities();
+            const table_entities = entities.filter((e) => e.model.label_class === "table");
+            table_entities.forEach((entity) => {
+                if (entity.distance_to_point(this.compute_centroid()) < 10) {
+                    const bbox = entity.compute_bounding_box();
+                    const columns = entities.filter((e) => {
+                        return entity_id !== e.get_entity_id() && e.model.label_class === "table_column" && bbox.contains_point(e.compute_bounding_box().centre());
+                    }).map((e) => e.compute_bounding_box());
+                    const rows = entities.filter((e) => {
+                        return entity_id !== e.get_entity_id() && e.model.label_class === "table_row" && bbox.contains_point(e.compute_bounding_box().centre());
+                    }).map((e) => e.compute_bounding_box());
+
+                    this._table = {
+                        bbox,
+                        columns,
+                        entity,
+                        label: this.model.label_class,
+                        rows,
+                        threshold: {
+                            x: Math.max(10, Math.ceil((bbox.upper.x - bbox.lower.x) / 100)),
+                            y: Math.max(10, Math.ceil((bbox.upper.y - bbox.lower.y) / 100)),
+                        }
+                    };
+                    return this._table;
+                }
+            });
+
+            return null;
         }
     }
 
@@ -268,6 +326,7 @@ module labelling_tool {
                 if (this._start_point !== null) {
                     if (this._current_point !== null) {
                         box = AABox_from_points([this._start_point, this._current_point]);
+                        box = this.get_table_box(this._start_point, this._current_point) ?? box;
                     }
                     else {
                         box = new AABox(this._start_point, this._start_point);
@@ -278,5 +337,67 @@ module labelling_tool {
                 this.entity.update();
             }
         };
+
+        get_table_box(_start: Vector2, _current: Vector2): AABox|null {
+            const table = this.entity.get_parent_table();
+            if (table === null) return null;
+
+            const bbox = table.bbox;
+            const start = bbox.closest_point_to(_start);
+            const current = bbox.closest_point_to(_current);
+            let box: AABox = null;
+
+            if (table.label === "table_row" || table.label === "table_column_header" || table.label === "table_projected_row_header") {
+                // full width
+                start.x = bbox.closest_boundary_to(start).x;
+                current.x = start.x === bbox.lower.x ? bbox.upper.x : bbox.lower.x;
+
+                this._snap_to_table_boundary(start, current, table, "y");
+                this._snap_to_row_boundary(start, current, table);
+            } else if (table.label === "table_column") {
+                // full height
+                start.y = bbox.closest_boundary_to(start).y;
+                current.y = start.y === bbox.lower.y ? bbox.upper.y : bbox.lower.y;
+
+                this._snap_to_table_boundary(start, current, table, "x");
+                this._snap_to_column_boundary(start, current, table);
+            // spanning cell
+            } else {
+                this._snap_to_table_boundary(start, current, table);
+                this._snap_to_column_boundary(start, current, table);
+                this._snap_to_row_boundary(start, current, table);
+            }
+
+            this._start_point = start;
+            box = AABox_from_points([start, current]);
+
+            return box;
+        }
+
+        _snap_to_table_boundary(start:Vector2, current:Vector2, table:TableStructure, type?: "x"|"y") {
+            if (type === undefined || type === "x") {
+                if (table.bbox.distance_to(start) < table.threshold.x) start.x = table.bbox.closest_point_to(start).x;
+                if (table.bbox.distance_to(current) < table.threshold.x) current.x = table.bbox.closest_point_to(current).x;
+            }
+            if (type === undefined || type === "y") {
+                if (table.bbox.distance_to(start) < table.threshold.y) start.y = table.bbox.closest_point_to(start).y;
+                if (table.bbox.distance_to(current) < table.threshold.y) current.y = table.bbox.closest_point_to(current).y;
+            }
+        }
+
+        // can break with below if matching multiple columns or rows
+        _snap_to_column_boundary(start:Vector2, current:Vector2, table:TableStructure) {
+            table.columns.forEach((col) => {
+               if (col.distance_to(start) < table.threshold.x) start.x = col.closest_boundary_to(start).x;
+               if (col.distance_to(current) < table.threshold.x) current.x = col.closest_boundary_to(current).x;
+            });
+        }
+
+        _snap_to_row_boundary(start:Vector2, current:Vector2, table:TableStructure) {
+            table.rows.forEach((row) => {
+               if (row.distance_to(start) < table.threshold.y) start.y = row.closest_boundary_to(start).y;
+               if (row.distance_to(current) < table.threshold.y) current.y = row.closest_boundary_to(current).y;
+            });
+        }
     }
 }

--- a/image_labelling_tool/static/labelling_tool/math_primitives.js
+++ b/image_labelling_tool/static/labelling_tool/math_primitives.js
@@ -132,6 +132,13 @@ var labelling_tool;
             var y = Math.max(this.lower.y, Math.min(this.upper.y, p.y));
             return { x: x, y: y };
         };
+        AABox.prototype.closest_boundary_to = function (p) {
+            var lower_d = sub_Vector2(this.lower, p);
+            var upper_d = sub_Vector2(this.upper, p);
+            var x = Math.abs(lower_d.x) <= Math.abs(upper_d.x) ? this.lower.x : this.upper.x;
+            var y = Math.abs(lower_d.y) <= Math.abs(upper_d.y) ? this.lower.y : this.upper.y;
+            return { x: x, y: y };
+        };
         AABox.prototype.sqr_distance_to = function (p) {
             var c = this.closest_point_to(p);
             var dx = c.x - p.x, dy = c.y - p.y;

--- a/image_labelling_tool/static/labelling_tool/math_primitives.ts
+++ b/image_labelling_tool/static/labelling_tool/math_primitives.ts
@@ -165,6 +165,14 @@ module labelling_tool {
             return {x: x, y: y};
         }
 
+        closest_boundary_to(p: Vector2): Vector2 {
+            const lower_d = sub_Vector2(this.lower, p)
+            const upper_d = sub_Vector2(this.upper, p)
+            const x = Math.abs(lower_d.x) <= Math.abs(upper_d.x) ? this.lower.x : this.upper.x;
+            const y = Math.abs(lower_d.y) <= Math.abs(upper_d.y) ? this.lower.y : this.upper.y;
+            return {x, y};
+        }
+
         sqr_distance_to(p: Vector2): number {
             var c = this.closest_point_to(p);
             var dx: number = c.x - p.x, dy: number = c.y - p.y;


### PR DESCRIPTION
## Description
Add specific functions to handle the drawing on box labels on tables.

Ensures that each table structure label is bounded by the table it is
closest to.
For each table row, sets the boundaries to the full width.
For each table column, sets the boundaries to the full height.
Allows the snapping to the closest row or column.
Allows both snapping for spanning cells.

[Wrike Task](https://www.wrike.com/open.htm?id=1371928971)

### Notes
Can possibly break when snapping to nearest row or column if there are two or more within the threshold. Should only be the case for extremely large tables > 200 rows or very small images.

[table_labeling.webm](https://github.com/elevatesystems/django-labeller/assets/1848121/74f24404-748a-4ed5-8325-5e9c26cecd2e)