### PR TITLE
feat: Fix typescript and remove unused controls

### DIFF
--- a/image_labelling_tool/flask_labeller.py
+++ b/image_labelling_tool/flask_labeller.py
@@ -453,8 +453,8 @@ def run_app(images_dir, images_pat, labels_dir, readonly, update_label_object_id
     #   `labelling_tool.AnnoControlText`; only the 2 common parameters listed above and:
     #       - multiline: boolean; if True a text area will be used, if False a single line text entry
     anno_controls = [
-        labelling_tool.AnnoControlCheckbox('good_quality', 'Good quality',
-                                           visibility_label_text='Filter by good quality'),
+        # labelling_tool.AnnoControlCheckbox('good_quality', 'Good quality',
+        #                                    visibility_label_text='Filter by good quality'),
         labelling_tool.AnnoControlRadioButtons('visibility', 'Visible', choices=[
             labelling_tool.AnnoControlRadioButtons.choice(value='full', label_text='Fully',
                                                           tooltip='Object is fully visible'),
@@ -463,27 +463,27 @@ def run_app(images_dir, images_pat, labels_dir, readonly, update_label_object_id
             labelling_tool.AnnoControlRadioButtons.choice(value='obscured', label_text='Obscured',
                                                           tooltip='Object is significantly obscured'),
         ], label_on_own_line=False, visibility_label_text='Filter by visibility'),
-        labelling_tool.AnnoControlPopupMenu('material', 'Material', groups=[
-            labelling_tool.AnnoControlPopupMenu.group(label_text='Artifical/buildings', choices=[
-                labelling_tool.AnnoControlPopupMenu.choice(value='concrete', label_text='Concrete',
-                                                           tooltip='Concrete objects'),
-                labelling_tool.AnnoControlPopupMenu.choice(value='plastic', label_text='Plastic',
-                                                           tooltip='Plastic objects'),
-                labelling_tool.AnnoControlPopupMenu.choice(value='asphalt', label_text='Asphalt',
-                                                           tooltip='Road, pavement, etc.'),
-            ]),
-            labelling_tool.AnnoControlPopupMenu.group(label_text='Flat natural', choices=[
-                labelling_tool.AnnoControlPopupMenu.choice(value='grass', label_text='Grass',
-                                                           tooltip='Grass covered ground'),
-                labelling_tool.AnnoControlPopupMenu.choice(value='water', label_text='Water', tooltip='Water/lake')]),
-            labelling_tool.AnnoControlPopupMenu.group(label_text='Vegetation', choices=[
-                labelling_tool.AnnoControlPopupMenu.choice(value='trees', label_text='Trees', tooltip='Trees'),
-                labelling_tool.AnnoControlPopupMenu.choice(value='shrubbery', label_text='Shrubs',
-                                                           tooltip='Shrubs/bushes'),
-                labelling_tool.AnnoControlPopupMenu.choice(value='flowers', label_text='Flowers',
-                                                           tooltip='Flowers'),
-                labelling_tool.AnnoControlPopupMenu.choice(value='ivy', label_text='Ivy', tooltip='Ivy')]),
-        ], visibility_label_text='Filter by material'),
+        # labelling_tool.AnnoControlPopupMenu('material', 'Material', groups=[
+        #     labelling_tool.AnnoControlPopupMenu.group(label_text='Artifical/buildings', choices=[
+        #         labelling_tool.AnnoControlPopupMenu.choice(value='concrete', label_text='Concrete',
+        #                                                    tooltip='Concrete objects'),
+        #         labelling_tool.AnnoControlPopupMenu.choice(value='plastic', label_text='Plastic',
+        #                                                    tooltip='Plastic objects'),
+        #         labelling_tool.AnnoControlPopupMenu.choice(value='asphalt', label_text='Asphalt',
+        #                                                    tooltip='Road, pavement, etc.'),
+        #     ]),
+        #     labelling_tool.AnnoControlPopupMenu.group(label_text='Flat natural', choices=[
+        #         labelling_tool.AnnoControlPopupMenu.choice(value='grass', label_text='Grass',
+        #                                                    tooltip='Grass covered ground'),
+        #         labelling_tool.AnnoControlPopupMenu.choice(value='water', label_text='Water', tooltip='Water/lake')]),
+        #     labelling_tool.AnnoControlPopupMenu.group(label_text='Vegetation', choices=[
+        #         labelling_tool.AnnoControlPopupMenu.choice(value='trees', label_text='Trees', tooltip='Trees'),
+        #         labelling_tool.AnnoControlPopupMenu.choice(value='shrubbery', label_text='Shrubs',
+        #                                                    tooltip='Shrubs/bushes'),
+        #         labelling_tool.AnnoControlPopupMenu.choice(value='flowers', label_text='Flowers',
+        #                                                    tooltip='Flowers'),
+        #         labelling_tool.AnnoControlPopupMenu.choice(value='ivy', label_text='Ivy', tooltip='Ivy')]),
+        # ], visibility_label_text='Filter by material'),
         # labelling_tool.AnnoControlText('comment', 'Comment', multiline=False),
     ]
 

--- a/image_labelling_tool/static/labelling_tool/main_labeller.js
+++ b/image_labelling_tool/static/labelling_tool/main_labeller.js
@@ -243,7 +243,7 @@ var labelling_tool;
             // Frozen flag; while frozen, data will not be sent to backend
             this.frozen = false;
             this._lockableControls = $('.anno_lockable');
-            // Toggle ability to right click (Keybind: L)
+            // Toggle ability to right-click (Keybind: L)
             this._lockRightClick = false;
             // Allow for permanent unsafe delete (delete without modal popup)
             this._allowPermanentDelete = false;
@@ -347,11 +347,11 @@ var labelling_tool;
                     type: 'GET',
                     url: '/get_api_labels/' + self._get_current_image_id(),
                     dataType: 'text',
-                    success: function(response) {
+                    success: function (response) {
                         console.log(response);
                         self.loadImage(self._images[self._image_id_to_index(self._get_current_image_id())]);
                     },
-                    error: function(response) {
+                    error: function (response) {
                         console.log(response);
                     }
                 });
@@ -525,7 +525,6 @@ var labelling_tool;
                         self.root_view.delete_selection(canDelete);
                     });
                 });
-
                 var unsafe_delete_label_button = $('#unsafe_delete_label_button');
                 unsafe_delete_label_button.click(function (event) {
                     self.root_view.delete_selection(canDelete);
@@ -722,9 +721,8 @@ var labelling_tool;
                 else if (button_event.button === 2) {
                     if (_this._lockRightClick) {
                         button_event.stopPropagation();
-                        return
+                        return;
                     }
-
                     // Right click; on_cancel current tool
                     if (_this._current_tool !== null) {
                         var handled = _this._current_tool.on_cancel(self.get_mouse_pos_world_space());
@@ -842,31 +840,28 @@ var labelling_tool;
         };
         DjangoLabeller.prototype.on_key_down = function (event) {
             var handled = false;
-
             // L to Lock
             if (event.keyCode === 76) {
-                const toggleLockIcon = () => {
-                    const lockIcon = document.getElementById("lockIcon");
+                var toggleLockIcon = function () {
+                    var lockIcon = document.getElementById("lockIcon");
                     if (lockIcon.style.display === "none") {
                         lockIcon.style.display = "block";
-                    } else {
+                    }
+                    else {
                         lockIcon.style.display = "none";
                     }
                 };
-
                 this._lockRightClick = !this._lockRightClick;
                 toggleLockIcon();
-
                 handled = true;
             }
-
             // DEL to Unsafe Delete
             if (event.keyCode === 46) {
                 var unsafe_delete_label_button = $('#unsafe_delete_label_button');
-                if (unsafe_delete_label_button) unsafe_delete_label_button.click();
+                if (unsafe_delete_label_button)
+                    unsafe_delete_label_button.click();
                 handled = true;
             }
-
             if (event.keyCode === 186) {
                 if (this.label_visibility === labelling_tool.LabelVisibility.HIDDEN) {
                     this.set_label_visibility(labelling_tool.LabelVisibility.FULL);

--- a/image_labelling_tool/static/labelling_tool/main_labeller.ts
+++ b/image_labelling_tool/static/labelling_tool/main_labeller.ts
@@ -174,6 +174,9 @@ module labelling_tool {
         private _lockableControls: JQuery;
         private _lockNotification: JQuery;
 
+        private _lockRightClick: boolean;
+        private _allowPermanentDelete: boolean;
+
 
 
 
@@ -382,6 +385,11 @@ module labelling_tool {
 
 
             this._lockableControls = $('.anno_lockable');
+
+            // Toggle ability to right-click (Keybind: L)
+            this._lockRightClick = false;
+            // Allow for permanent unsafe delete (delete without modal popup)
+            this._allowPermanentDelete = false;
 
 
 
@@ -708,6 +716,11 @@ module labelling_tool {
                         self.root_view.delete_selection(canDelete);
                     });
                 });
+
+                var unsafe_delete_label_button = $('#unsafe_delete_label_button');
+                unsafe_delete_label_button.click(function (event) {
+                    self.root_view.delete_selection(canDelete);
+                });
             }
 
             if (config.tools.labelClassSelector) {
@@ -947,6 +960,11 @@ module labelling_tool {
                     }
                 }
                 else if (button_event.button === 2) {
+                    if (this._lockRightClick) {
+                        button_event.stopPropagation();
+                        return;
+                    }
+
                     // Right click; on_cancel current tool
                     if (this._current_tool !== null) {
                         var handled = this._current_tool.on_cancel(self.get_mouse_pos_world_space());
@@ -1082,6 +1100,31 @@ module labelling_tool {
 
         on_key_down(event: any): boolean {
             var handled = false;
+
+            // L to Lock
+            if (event.keyCode === 76) {
+                const toggleLockIcon = () => {
+                    const lockIcon = document.getElementById("lockIcon");
+                    if (lockIcon.style.display === "none") {
+                        lockIcon.style.display = "block";
+                    } else {
+                        lockIcon.style.display = "none";
+                    }
+                };
+
+                this._lockRightClick = !this._lockRightClick;
+                toggleLockIcon();
+
+                handled = true;
+            }
+
+            // DEL to Unsafe Delete
+            if (event.keyCode === 46) {
+                var unsafe_delete_label_button = $('#unsafe_delete_label_button');
+                if (unsafe_delete_label_button) unsafe_delete_label_button.click();
+                handled = true;
+            }
+
             if (event.keyCode === 186) {
                 if (this.label_visibility === LabelVisibility.HIDDEN) {
                     this.set_label_visibility(LabelVisibility.FULL);

--- a/image_labelling_tool/static/labelling_tool/select_tools.js
+++ b/image_labelling_tool/static/labelling_tool/select_tools.js
@@ -105,10 +105,10 @@ var labelling_tool;
         SelectEntityTool.prototype.on_left_click = function (pos, event) {
             this._update_entities_under_pointer(pos);
             if (this._current_entity !== null) {
-                this._view.select_entity(this._current_entity, event.shiftKey, true);
+                this._view.select_entity(this._current_entity, event.shiftKey || event.ctrlKey, true);
             }
             else {
-                if (!event.shiftKey) {
+                if (!event.shiftKey && !event.ctrlKey) {
                     this._view.unselect_all_entities();
                 }
             }

--- a/image_labelling_tool/static/labelling_tool/select_tools.ts
+++ b/image_labelling_tool/static/labelling_tool/select_tools.ts
@@ -100,10 +100,10 @@ module labelling_tool {
         on_left_click(pos: Vector2, event: any) {
             this._update_entities_under_pointer(pos);
             if (this._current_entity !== null) {
-                this._view.select_entity(this._current_entity, event.shiftKey, true);
+                this._view.select_entity(this._current_entity, event.shiftKey || event.ctrlKey, true);
             }
             else {
-                if (!event.shiftKey) {
+                if (!event.shiftKey && !event.ctrlKey) {
                     this._view.unselect_all_entities();
                 }
             }


### PR DESCRIPTION
## Description
Fix typescript on main_labeller from previous lock delete changes.
Remove Material and Quality annotation controls. Can be added later.

### Notes
Load the diff on `image_labelling_tool/static/labelling_tool/main_labeller.js` to see the actual changes.

To compile the typescript install typescript globally
```
npm install -g typescript
```
and go to the specific directory and run
```
tsc image_labelling_tool/static/labelling_tool/main_labeller.ts
```
You may need to remove some excess compiled artifacts from the compiled js output.