### PR TITLE
Remove Pointer Circle From Polygonal Label Tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # OSX
 **.DS_Store
 
@@ -150,3 +151,14 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+# Default ignored files
+shelf/
+workspace.xml
+# Editor-based HTTP Client requests
+httpRequests/
+# Datasource local storage ignored files
+dataSources/
+dataSources.local.xml
+# Other ignored files
+django_labeller.egg-info/
+image_labelling_tool/__pycache__/

--- a/image_labelling_tool/static/labelling_tool/abstract_label.js
+++ b/image_labelling_tool/static/labelling_tool/abstract_label.js
@@ -238,4 +238,3 @@ var labelling_tool;
     }
     labelling_tool.model_map = model_map;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=abstract_label.js.map

--- a/image_labelling_tool/static/labelling_tool/abstract_tool.js
+++ b/image_labelling_tool/static/labelling_tool/abstract_tool.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -236,4 +238,3 @@ var labelling_tool;
     }(AbstractTool));
     labelling_tool.ProxyTool = ProxyTool;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=abstract_tool.js.map

--- a/image_labelling_tool/static/labelling_tool/anno_controls.js
+++ b/image_labelling_tool/static/labelling_tool/anno_controls.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -221,4 +223,3 @@ var labelling_tool;
     }());
     labelling_tool.AnnotationVisFilter = AnnotationVisFilter;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=anno_controls.js.map

--- a/image_labelling_tool/static/labelling_tool/box_label.js
+++ b/image_labelling_tool/static/labelling_tool/box_label.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -369,4 +371,3 @@ var labelling_tool;
     }(labelling_tool.AbstractTool));
     labelling_tool.DrawBoxTool = DrawBoxTool;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=box_label.js.map

--- a/image_labelling_tool/static/labelling_tool/composite_label.js
+++ b/image_labelling_tool/static/labelling_tool/composite_label.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -220,4 +222,3 @@ var labelling_tool;
         return new CompositeLabelEntity(root_view, model);
     });
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=composite_label.js.map

--- a/image_labelling_tool/static/labelling_tool/dextr_label.js
+++ b/image_labelling_tool/static/labelling_tool/dextr_label.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -355,4 +357,3 @@ var labelling_tool;
     }(labelling_tool.AbstractTool));
     labelling_tool.DextrTool = DextrTool;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=dextr_label.js.map

--- a/image_labelling_tool/static/labelling_tool/group_label.js
+++ b/image_labelling_tool/static/labelling_tool/group_label.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -261,4 +263,3 @@ var labelling_tool;
         }
     });
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=group_label.js.map

--- a/image_labelling_tool/static/labelling_tool/main_labeller.js
+++ b/image_labelling_tool/static/labelling_tool/main_labeller.js
@@ -1369,4 +1369,3 @@ var labelling_tool;
     }());
     labelling_tool.DjangoLabeller = DjangoLabeller;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=main_labeller.js.map

--- a/image_labelling_tool/static/labelling_tool/object_id_table.js
+++ b/image_labelling_tool/static/labelling_tool/object_id_table.js
@@ -109,4 +109,3 @@ var labelling_tool;
     }());
     labelling_tool.ObjectIDTable = ObjectIDTable;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=object_id_table.js.map

--- a/image_labelling_tool/static/labelling_tool/oriented_ellipse_label.js
+++ b/image_labelling_tool/static/labelling_tool/oriented_ellipse_label.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -376,4 +378,3 @@ var labelling_tool;
     }(labelling_tool.AbstractTool));
     labelling_tool.DrawOrientedEllipseTool = DrawOrientedEllipseTool;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=oriented_ellipse_label.js.map

--- a/image_labelling_tool/static/labelling_tool/point_label.js
+++ b/image_labelling_tool/static/labelling_tool/point_label.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -184,4 +186,3 @@ var labelling_tool;
     }(labelling_tool.AbstractTool));
     labelling_tool.DrawPointTool = DrawPointTool;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=point_label.js.map

--- a/image_labelling_tool/static/labelling_tool/polygonal_label.js
+++ b/image_labelling_tool/static/labelling_tool/polygonal_label.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -630,9 +632,9 @@ var labelling_tool;
             this._last_vertex_marker = this._view.world.append("circle");
             this._last_vertex_marker.attr("r", "3.0");
             this._last_vertex_marker.attr("visibility", "hidden");
-            this._last_vertex_marker.style("fill", "rgba(128,0,192,0.1)");
-            this._last_vertex_marker.style("stroke-width", "1.5");
-            this._last_vertex_marker.style("stroke", "rgba(0,128,255,1.0)");
+            this._last_vertex_marker.style("fill", "rgba(0,0,0,0)");
+            this._last_vertex_marker.style("stroke-width", "0");
+            this._last_vertex_marker.style("stroke", "rgba(0,0,0,0)");
             this._last_vertex_marker_visible = false;
         };
         ;
@@ -916,4 +918,3 @@ var labelling_tool;
         return DrawBrushTool;
     }(labelling_tool.AbstractTool));
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=polygonal_label.js.map

--- a/image_labelling_tool/static/labelling_tool/polygonal_label.ts
+++ b/image_labelling_tool/static/labelling_tool/polygonal_label.ts
@@ -717,9 +717,9 @@ module labelling_tool {
             this._last_vertex_marker = this._view.world.append("circle");
             this._last_vertex_marker.attr("r", "3.0");
             this._last_vertex_marker.attr("visibility", "hidden");
-            this._last_vertex_marker.style("fill", "rgba(128,0,192,0.1)");
-            this._last_vertex_marker.style("stroke-width", "1.5");
-            this._last_vertex_marker.style("stroke", "rgba(0,128,255,1.0)");
+            this._last_vertex_marker.style("fill", "rgba(0,0,0,0)");
+            this._last_vertex_marker.style("stroke-width", "0");
+            this._last_vertex_marker.style("stroke", "rgba(0,0,0,0)");
             this._last_vertex_marker_visible = false;
         };
 

--- a/image_labelling_tool/static/labelling_tool/root_label_view.js
+++ b/image_labelling_tool/static/labelling_tool/root_label_view.js
@@ -485,4 +485,3 @@ var labelling_tool;
     }());
     labelling_tool.RootLabelView = RootLabelView;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=root_label_view.js.map

--- a/image_labelling_tool/static/labelling_tool/schema.js
+++ b/image_labelling_tool/static/labelling_tool/schema.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -120,4 +122,3 @@ var labelling_tool;
     }
     labelling_tool.label_classes_from_json = label_classes_from_json;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=schema.js.map

--- a/image_labelling_tool/static/labelling_tool/select_tools.js
+++ b/image_labelling_tool/static/labelling_tool/select_tools.js
@@ -32,6 +32,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -303,4 +305,3 @@ var labelling_tool;
     }(labelling_tool.AbstractTool));
     labelling_tool.BrushSelectEntityTool = BrushSelectEntityTool;
 })(labelling_tool || (labelling_tool = {}));
-//# sourceMappingURL=select_tools.js.map


### PR DESCRIPTION
# Overview

This PR removes the styling that makes the pointer circle visible on the browser, effectively removing it without discarding the way the pointer works to draw the label.

# Screenshots
![image](https://github.com/Britefury/django-labeller/assets/118487667/1f8f3cf0-dce0-4943-a675-d02c0f24f09c)
_this was taken mid label drawing_